### PR TITLE
Front page who

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ var path = require("path");
 var Pool = require("pg-pool");
 var config = require("config");
 var ensureProjectionsTable = require("./ensureProjectionsTable.js");
+var frontPageSelector = require("./frontPageSelector.js");
 
 var pool = new Pool(config.postgres);
 
@@ -33,7 +34,7 @@ app.use(function failMiddleware(req, res, next) {
 });
 
 app.use("/assets", express.static(path.join(__dirname, "assets")));
-app.get("/", staticViewEndpoint("prelaunch/view.html"));
+app.get("/", frontPageSelector);
 app.post("/subscribe", subscribeEndpoint(pool));
 app.get("/du-er-paa-listen", staticViewEndpoint("prelaunch/subscription-succesful-view.html"));
 app.get("/unsubscribe/:id", unsubscribeEndpoint(pool));

--- a/downtime/view.html
+++ b/downtime/view.html
@@ -1,5 +1,7 @@
 ---
 layout: oldstyle
 ---
-
-Page shown when season is over.
+<div class="floaty-content-box">
+    <h1>Salget er slut!</h1>
+    <p>Kom igen når vi åbner salget efter sommer.</p>
+</div>

--- a/downtime/view.html
+++ b/downtime/view.html
@@ -1,0 +1,5 @@
+---
+layout: oldstyle
+---
+
+Page shown when season is over.

--- a/frontPageSelector.js
+++ b/frontPageSelector.js
@@ -6,6 +6,10 @@ function frontPageSelector(req, res) {
         var sales = staticViewEndpoint("sales/view.html");
         return sales(req, res);
     }
+    if(req.query.forceState == "salesEnded") {
+        var downtime = staticViewEndpoint("downtime/view.html");
+        return downtime(req, res);
+    }
     
     var prelaunch = staticViewEndpoint("prelaunch/view.html");
     prelaunch(req, res);

--- a/frontPageSelector.js
+++ b/frontPageSelector.js
@@ -1,6 +1,12 @@
 var staticViewEndpoint = require("./staticViewEndpoint.js");
 
 function frontPageSelector(req, res) {
+    //TODO: On certain dates to certain things.
+    if(req.query.forceState == "salesStarted") {
+        var sales = staticViewEndpoint("sales/view.html");
+        return sales(req, res);
+    }
+    
     var prelaunch = staticViewEndpoint("prelaunch/view.html");
     prelaunch(req, res);
 }

--- a/frontPageSelector.js
+++ b/frontPageSelector.js
@@ -1,17 +1,17 @@
 var staticViewEndpoint = require("./staticViewEndpoint.js");
+var sales = staticViewEndpoint("sales/view.html");
+var downtime = staticViewEndpoint("downtime/view.html");
+var prelaunch = staticViewEndpoint("prelaunch/view.html");
 
 function frontPageSelector(req, res) {
     //TODO: On certain dates to certain things.
     if(req.query.forceState == "salesStarted") {
-        var sales = staticViewEndpoint("sales/view.html");
         return sales(req, res);
     }
     if(req.query.forceState == "salesEnded") {
-        var downtime = staticViewEndpoint("downtime/view.html");
         return downtime(req, res);
     }
     
-    var prelaunch = staticViewEndpoint("prelaunch/view.html");
     prelaunch(req, res);
 }
 

--- a/frontPageSelector.js
+++ b/frontPageSelector.js
@@ -1,0 +1,8 @@
+var staticViewEndpoint = require("./staticViewEndpoint.js");
+
+function frontPageSelector(req, res) {
+    var prelaunch = staticViewEndpoint("prelaunch/view.html");
+    prelaunch(req, res);
+}
+
+module.exports = frontPageSelector;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etree2",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "etree service in node",
   "scripts": {
     "start": "node app.js",

--- a/sales/view.html
+++ b/sales/view.html
@@ -2,5 +2,19 @@
 layout: default
 ---
 <div class="sales-container">
+    <!-- PICK TREE SIZE -->
+    <!--  & with/without foot? -->
+    <!--  & how does it look if we have 5 trees left of a size/when we've run out? -->
+    
+    <!-- CUSTOMER INFORMATION -->
+    <!-- Fakturaadresse inkl navn, vej linje 1+2, postnr, by -->
+    <!-- Leveringsadresse hvis forskellig -->
+    <!-- Email (påkrævet) -->
+    <!-- Mobiltelefonnummer (valgfrit) -->
+    <!-- Kommentarer (påkrævet) -->
+    
+    <!-- SUMMARY (når alt er fyldt ud) -->
+    <!-- Tryk køb for endeligt at gå til betaling -->
+    
     something something sales
 </div>

--- a/sales/view.html
+++ b/sales/view.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<div class="sales-container">
+    something something sales
+</div>


### PR DESCRIPTION
Added a frontPageSelector, that makes sure to show the correct frontpage depending on state.

Right now it is triggered by passing query parameters to a request.
- To see the downtime page, go to `/?forceState=salesEnded`
- To see the sales page, go to `/?forceState=salesStarted`

The selector will eventually be changed to automatically pick the correct view based on what date it currently is (once all the views are ready for launch).

@Arth101 this should be the basic scaffolding needed for you to start designing the sales page. I have added an outline of the elements needed on the page. As noted above, go to `/?forceState=salesStarted` to see the page. The view is in `/sales/view.html`.
