### PR TITLE
Tree size ux

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -119,6 +119,9 @@ h3.subline {
     padding: 20px;
   }
 }
+.underline {
+  text-decoration: underline;
+}
 textarea {
   display: block;
   width: 100%;

--- a/assets/style.css
+++ b/assets/style.css
@@ -512,7 +512,7 @@ input[name="pickup-place"]:checked+label .checkmark-icon {
 }
 @media(max-width:600px){
   .trees .tree-size-container {
-    width: 50%;
+    width: 100%;
     margin-bottom: 10px;
   }
   .trees .tree-size-container .fa-tree {
@@ -524,10 +524,6 @@ input[name="pickup-place"]:checked+label .checkmark-icon {
   .tree-size h4 {
     margin-top: 0;
   }
-}
-.tree .tree-size ul {
-  list-style: none;
-  padding: 0;
 }
 .trees .tree-size ul li:first-of-type {
   font-weight: 600;
@@ -542,13 +538,26 @@ input[name="pickup-place"]:checked+label .checkmark-icon {
   padding: 0;
   margin: 0;
   color: black;
-  background: white;
+  background: rgba(171, 220, 183, 1);
 }
 .tree-size ul li {
   padding: 10px 0;
 }
 .tree-size ul li:nth-child(odd) {
   background: #eee;
+}
+@media(max-width: 600px){
+  .trees .tree-size ul {
+    background: inherit;
+    color: white;
+  }
+  .tree-size ul li {
+    padding: 0;
+    padding-top: 10px;
+  }
+  .tree-size ul li:nth-child(odd) {
+    background: inherit;
+  }
 }
 .tree-size a.btn {
   padding: 6px 12px;
@@ -556,27 +565,11 @@ input[name="pickup-place"]:checked+label .checkmark-icon {
   font-weight: 600;
   background: transparent;
 }
-.tree .tree-size ul {
-  list-style: none;
-  padding: 0;
-}
-.trees .tree-size h4 {
-  background: #306f3f;
-  padding: 10px;
-  margin-bottom: 0;
-}
-.trees .tree-size ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  color: black;
-  background: white;
-}
-.tree-size ul li {
-  padding: 10px 0;
-}
-.tree-size ul li:nth-child(odd) {
-  background: #eee;
+@media(max-width: 600px){
+  .tree-size a.btn {
+    font-size: 2em;
+    margin-top: 10px;
+  }
 }
 
 .sales-options {

--- a/assets/style.css
+++ b/assets/style.css
@@ -204,7 +204,7 @@ textarea {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: calc(100vh - 325px);
+  height: calc(100vh - 365px);
   min-height: 400px;
   padding: 20px;
   box-sizing: border-box;
@@ -294,7 +294,7 @@ table tr td {
 .sign-up-bar {
   width: 100%;
   padding: 40px 20px;
-  background: rgba(51, 51, 51, 0.9);
+  background: rgba(51, 51, 51, 0.85);
   color: white;
   box-sizing: border-box;
   text-align: center;
@@ -441,11 +441,11 @@ footer.floaty-content-box {
 .sales-container {
   background: rgb(250,250,250);
   box-sizing: border-box;
-  padding: 60px;
+  padding: 60px 0;
 }
 @media(max-width: 600px){
   .sales-container {
-    padding: 20px;
+    padding: 20px 0;
   }
 }
 
@@ -474,7 +474,7 @@ input[name="pickup-place"] {
 input[name="tree-size"]:checked+label,
 input[name="pickup-place"]:checked+label {
   background: #306F3F;
-  transform: scale(1.15);
+  transform: scale(1.05);
 }
 input[name="tree-size"]:checked+label .checkmark-icon,
 input[name="pickup-place"]:checked+label .checkmark-icon {
@@ -513,6 +513,7 @@ input[name="pickup-place"]:checked+label .checkmark-icon {
 @media(max-width:600px){
   .trees .tree-size-container {
     width: 100%;
+    max-width: 280px;
     margin-bottom: 10px;
   }
   .trees .tree-size-container .fa-tree {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etree2",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "etree service in node",
   "scripts": {
     "start": "node app.js",

--- a/sales/productDataBackup.json
+++ b/sales/productDataBackup.json
@@ -2,7 +2,7 @@
   "pickUpLocations": [
     {
         "name": "Sjov & spas",
-        "image": "firforest.jpg",
+        "image": "etreeLogo.png",
         "address": "Strandvejen 267, Charlottenlund",
         "time": "30. nov kl. 12-16"
     }

--- a/sales/view.html
+++ b/sales/view.html
@@ -92,7 +92,7 @@ layout: sales
                 Hvis du har særlige ønsker til leveringstidspunkt, kan du skrive det i kommentarfeltet nedenfor.
             </p>
             {{^pickUpLocations.length}}
-              <p>Levering koster <strong>{{ deliveryPrice }} kr</strong></p>
+              <p class="underline">Levering koster <strong>{{ deliveryPrice }} kr</strong></p>
             {{/pickUpLocations.length}}
 
             {{#pickUpLocations.length}}

--- a/sales/view.html
+++ b/sales/view.html
@@ -53,7 +53,6 @@ layout: sales
                 {{#salesLimit}}
                 <li>Kun {{salesLimit}} tilbage!</li>
                 {{/salesLimit}}
-                <li>Leveres til døren</li>
               </ul>
               <a class="btn">{{price}} kr<span class="checkmark-icon">&nbsp;&#10003;</span></a>
             </div>

--- a/sales/view.html
+++ b/sales/view.html
@@ -206,7 +206,7 @@ layout: sales
               <div id="delivery-pickup-place" class="pickup-place-container" style="display:none;">
                 <p style="text-align:left;"><strong>Leveringsadresse</strong></p>
                 <div class="pickup-place">
-                  <img src="../assets/firforest.jpg" alt="" />
+                  <img src="../assets/etreeLogo.png" alt="" />
                   <div class="pickup-content">
                     <p><strong>Strandvejen 267</strong><br />
                       Charlottenlund<br />


### PR DESCRIPTION
Prøvede at gøre træstørrelserne mere overskueligt/bedre på mobil. Har fjernet 'vi leverer til døren' teksten.
Should resolve #69 and resolve #70

![screenshot from 2016-11-04 11-21-04](https://cloud.githubusercontent.com/assets/8166831/20002602/edd85d48-a281-11e6-8f27-fa4a37fcfbb0.png)
![screenshot from 2016-11-04 11-22-35](https://cloud.githubusercontent.com/assets/8166831/20002603/edecc4a4-a281-11e6-9745-fbc1e295e2bd.png)
